### PR TITLE
Remove printed line triggering IDE

### DIFF
--- a/src/main/java/com/hegesoftware/game/Entrance.java
+++ b/src/main/java/com/hegesoftware/game/Entrance.java
@@ -31,7 +31,7 @@ public class Entrance {
                 return player;
             }
 
-            System.out.println("Error: Couldn't load the game. Starting a new one.");
+            System.out.println("Couldn't load the game. Starting a new one.");
         }
 
         System.out.println("As a responsible casino, Gamba needs to know your name as a new player:");


### PR DESCRIPTION
Removed "Error: " from in front of tbe message shown to user if loading game fails. This gets rid of IntelliJ and possible other IDEs showing the line in red color in console, and preventing the user from interacting with console.

Fixes #5 